### PR TITLE
Add "browser" field for browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   ],
   "dependencies": {},
   "main": "index.js",
+  "browser": {
+    "buffer": false
+  },
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This aim to reduce file size of a bundle which is generated by browserify.

Ref [Reduce build file size by azu · Pull Request #297 · dekujs/deku](https://github.com/dekujs/deku/pull/297)

If browserify detects the use of Buffer, it will include a browser-appropriate definition.
This commit prevent shim of buffer is mixed into a bundle.

Demo of this issue is here: [azu/component-type-with-browserify-issue](https://github.com/azu/component-type-with-browserify-issue)

``` js
// input.js
var type = require("component-type");
```

Build `input.js` with browserify, then output.js's file size is 50KB...

Ref:
https://github.com/substack/browserify-handbook#browser-field
https://gist.github.com/defunctzombie/4339901
